### PR TITLE
Feature/CICD-91: Re-write the terraform code to deploy local VMs

### DIFF
--- a/hosts/backend.tf
+++ b/hosts/backend.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "local" {}
+}

--- a/hosts/main.tf
+++ b/hosts/main.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    libvirt = {
+      source  = "dmacvicar/libvirt"
+      version = "0.9.8"
+    }
+  }
+}
+
+provider "libvirt" {
+  uri = var.libvirt_uri
+}
+
+module "vm" {
+  source = "../modules/vm"
+
+  name              = var.name
+  memory            = var.memory
+  vcpu              = var.vcpu
+  autostart         = var.autostart
+  pool              = var.pool
+  pool_target_path  = var.pool_target_path
+  base_volume_name  = var.base_volume_name
+  disk_size         = var.disk_size
+  disk_size_unit    = var.disk_size_unit
+  mac_address       = var.mac_address
+  macvtap_interface = var.macvtap_interface
+  network_name      = var.network_name
+}

--- a/hosts/variables.tf
+++ b/hosts/variables.tf
@@ -1,0 +1,66 @@
+variable "libvirt_uri" {
+  type        = string
+  description = "Libvirt connection URI (e.g. qemu+ssh://user@host/system)"
+}
+
+variable "name" {
+  type        = string
+  description = "VM name (used for domain and volume)"
+}
+
+variable "memory" {
+  type        = number
+  default     = 1024
+  description = "RAM in MiB"
+}
+
+variable "vcpu" {
+  type    = number
+  default = 2
+}
+
+variable "autostart" {
+  type    = bool
+  default = true
+}
+
+variable "pool" {
+  type        = string
+  description = "Libvirt storage pool name"
+}
+
+variable "pool_target_path" {
+  type        = string
+  description = "Filesystem path where the libvirt pool stores volumes"
+}
+
+variable "base_volume_name" {
+  type        = string
+  description = "Filename of the base qcow2 image within pool_target_path"
+}
+
+variable "disk_size" {
+  type        = number
+  default     = 20
+  description = "VM disk size — must be >= base image virtual size"
+}
+
+variable "disk_size_unit" {
+  type    = string
+  default = "GiB"
+}
+
+variable "mac_address" {
+  type        = string
+  description = "MAC address for macvtap interface (lowercase — maps to static DHCP on Mikrotik)"
+}
+
+variable "macvtap_interface" {
+  type    = string
+  default = "enp0s25"
+}
+
+variable "network_name" {
+  type    = string
+  default = "default"
+}

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -1,0 +1,100 @@
+terraform {
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+    }
+  }
+}
+
+resource "libvirt_volume" "this" {
+  name          = "${var.name}.qcow2"
+  pool          = var.pool
+  capacity      = var.disk_size
+  capacity_unit = var.disk_size_unit
+
+  backing_store = {
+    path = "${var.pool_target_path}/${var.base_volume_name}"
+    format = {
+      type = "qcow2"
+    }
+  }
+
+  target = {
+    format = {
+      type = "qcow2"
+    }
+  }
+}
+
+resource "libvirt_domain" "this" {
+  name        = var.name
+  type        = "kvm"
+  memory      = var.memory
+  memory_unit = "MiB"
+  vcpu        = var.vcpu
+  autostart = var.autostart
+  running   = true
+
+  os = {
+    type         = "hvm"
+    type_arch    = "x86_64"
+    type_machine = "pc"
+  }
+
+  devices = {
+    disks = [
+      {
+        driver = {
+          name = "qemu"
+          type = "qcow2"
+        }
+        source = {
+          file = {
+            file = libvirt_volume.this.path
+          }
+        }
+        target = {
+          dev = "vda"
+          bus = "virtio"
+        }
+      }
+    ]
+
+    interfaces = [
+      {
+        model = { type = "virtio" }
+        mac   = { address = var.mac_address }
+        source = {
+          direct = {
+            dev  = var.macvtap_interface
+            mode = "bridge"
+          }
+        }
+      },
+      {
+        model = { type = "virtio" }
+        source = {
+          network = {
+            network = var.network_name
+          }
+        }
+      }
+    ]
+
+    serial = [
+      {
+        type = "pty"
+      }
+    ]
+
+    consoles = [
+      {
+        type = "pty"
+        target = {
+          type = "serial"
+          port = 0
+        }
+      }
+    ]
+  }
+}

--- a/modules/vm/outputs.tf
+++ b/modules/vm/outputs.tf
@@ -1,0 +1,7 @@
+output "id" {
+  value = libvirt_domain.this.id
+}
+
+output "name" {
+  value = libvirt_domain.this.name
+}

--- a/modules/vm/variables.tf
+++ b/modules/vm/variables.tf
@@ -1,0 +1,64 @@
+variable "name" {
+  type        = string
+  description = "VM name (used for domain and volume)"
+}
+
+variable "memory" {
+  type        = number
+  default     = 1024
+  description = "RAM in MiB"
+}
+
+variable "vcpu" {
+  type    = number
+  default = 2
+}
+
+variable "autostart" {
+  type    = bool
+  default = true
+}
+
+variable "pool" {
+  type        = string
+  description = "Libvirt storage pool for the VM disk"
+}
+
+variable "disk_size" {
+  type        = number
+  default     = 20
+  description = "VM disk size. Must be >= the virtual size of the base image (check with: qemu-img info --force-share <base.qcow2> | grep 'virtual size')"
+}
+
+variable "disk_size_unit" {
+  type        = string
+  default     = "GiB"
+  description = "Unit for disk_size (KiB, MiB, GiB, TiB)"
+}
+
+variable "pool_target_path" {
+  type        = string
+  description = "Filesystem path where the libvirt pool stores volumes. Find it with: virsh pool-dumpxml <pool> | grep '<path>'"
+}
+
+variable "base_volume_name" {
+  type        = string
+  description = "Filename of the base qcow2 image within pool_target_path (e.g. docker-base.qcow2)"
+}
+
+variable "mac_address" {
+  type        = string
+  description = "MAC address for the macvtap interface (maps to static DHCP lease on Mikrotik)"
+}
+
+variable "macvtap_interface" {
+  type        = string
+  default     = "enp0s25"
+  description = "Physical host NIC to attach macvtap to"
+}
+
+variable "network_name" {
+  type        = string
+  default     = "default"
+  description = "Secondary libvirt network name"
+}


### PR DESCRIPTION
This is the first iteration to get a VM up and down. 
The goal is to move away from a different repo per VM and have one repo for all VMs with a module that will help us have a single codebase. 


I will need a variables file such as `test.tfvars`: 

```
libvirt_uri      = "qemu+ssh://blah@blah2/system"

name             = "test-vm"
pool             = "test"
pool_target_path = "/vmhost_qcow/test"
base_volume_name = "test-vm-base.qcow2"
mac_address      = "52:54:00:ea:17:01"
disk_size        = 24
```


and then 

```
terrafrom plan -var-file=test.tfvars
terraform apply -var-file=test.tfvars
terraform destroy -var-file=test.tfvars
```

